### PR TITLE
Get and test api/articles

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -42,12 +42,40 @@ describe("GET /api/topics", () => {
       .get("/api/topics")
       .expect(200)
       .then(({ body: { topics } }) => {
-        expect(topics.length).toBe(3);
+        expect(topics.length).toBe(testData.topicData.length);
         topics.forEach((topic) => {
           expect(topic).toEqual(
             expect.objectContaining({
               slug: expect.any(String),
               description: expect.any(String),
+            })
+          );
+        });
+      });
+  });
+});
+
+describe("GET /api/articles", () => {
+  test("200: Responds with an array of article objects", () => {
+    return request(app)
+      .get("/api/articles")
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles.length).toBe(testData.articleData.length);
+        expect(articles).toBeSortedBy("created_at", {
+          descending: true,
+        });
+        articles.forEach((article) => {
+          expect(article).toEqual(
+            expect.objectContaining({
+              author: expect.any(String),
+              title: expect.any(String),
+              article_id: expect.any(Number),
+              topic: expect.any(String),
+              created_at: expect.any(String),
+              votes: expect.any(Number),
+              article_img_url: expect.any(String),
+              comment_count: expect.any(Number),
             })
           );
         });

--- a/app.js
+++ b/app.js
@@ -3,14 +3,20 @@ const app = express();
 const endpointsJson = require("./endpoints.JSON");
 
 const { getTopics } = require("./controllers/topics.controllers.js");
+const {
+  getArticles,
+  getArticleById,
+} = require("./controllers/articles.controllers.js");
 
-const { getArticleById } = require("./controllers/articles.controllers.js");
+// middleware
 
 app.get("/api", (req, res) => {
   res.status(200).send({ endpoints: endpointsJson });
 });
 
 app.get("/api/topics", getTopics);
+
+app.get("/api/articles", getArticles);
 
 app.get("/api/articles/:article_id", getArticleById);
 

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -1,4 +1,17 @@
-const { fetchArticleById } = require("../models/articles.models");
+const {
+  fetchArticles,
+  fetchArticleById,
+} = require("../models/articles.models");
+
+const getArticles = (req, res, next) => {
+  fetchArticles()
+    .then((articles) => {
+      res.status(200).send({ articles });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
 
 const getArticleById = (req, res, next) => {
   const { article_id } = req.params;
@@ -11,4 +24,4 @@ const getArticleById = (req, res, next) => {
     });
 };
 
-module.exports = { getArticleById };
+module.exports = { getArticles, getArticleById };

--- a/endpoints.json
+++ b/endpoints.json
@@ -10,18 +10,19 @@
     }
   },
   "GET /api/articles": {
-    "description": "serves an array of all articles",
+    "description": "serves an array of all articles, sorted by date ascending with a comment count that is total count of all the comments with this article_id.",
     "queries": ["author", "topic", "sort_by", "order"],
     "exampleResponse": {
       "articles": [
         {
-          "title": "Seafood substitutions are increasing",
-          "topic": "cooking",
-          "author": "weegembump",
-          "body": "Text from the article..",
-          "created_at": "2018-05-30T15:59:13.341Z",
+          "author": "icellusedkars",
+          "title": "Eight pug gifs that remind me of mitch",
+          "article_id": 3,
+          "topic": "mitch",
+          "created_at": "2020-11-03T09:12:00.000Z",
           "votes": 0,
-          "comment_count": 6
+          "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+          "comment_count": 2
         }
       ]
     }

--- a/models/articles.models.js
+++ b/models/articles.models.js
@@ -1,5 +1,21 @@
 const db = require("../db/connection");
 
+const fetchArticles = () => {
+  return db
+    .query(
+      `SELECT articles.author, articles.title, articles.article_id, articles.topic, articles.created_at, articles.votes, articles.article_img_url, COUNT(comments.article_id)::int AS comment_count
+         FROM articles
+         FULL JOIN comments
+         ON articles.article_id = comments.article_id
+         GROUP BY articles.author, articles.title, articles.article_id, articles.topic, articles.created_at, articles.votes, articles.article_img_url
+         ORDER BY articles.created_at DESC
+      `
+    )
+    .then(({ rows }) => {
+      return rows;
+    });
+};
+
 const fetchArticleById = (article_id) => {
   return db
     .query(`SELECT * FROM articles WHERE article_id=$1`, [article_id])
@@ -12,4 +28,4 @@ const fetchArticleById = (article_id) => {
     });
 };
 
-module.exports = { fetchArticleById };
+module.exports = { fetchArticles, fetchArticleById };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "husky": "^8.0.2",
         "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
+        "jest-sorted": "^1.0.15",
         "pg-format": "^1.0.4",
         "supertest": "^7.0.0"
       }
@@ -3005,6 +3006,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/jest-util": {
       "version": "27.5.1",
@@ -6942,6 +6950,12 @@
           }
         }
       }
+    },
+    "jest-sorted": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/jest-sorted/-/jest-sorted-1.0.15.tgz",
+      "integrity": "sha512-bb5HzfyUqv22ToD63KRACZiwHVRVVj6/bl53VOODNQSzmTwKuTM0zYI73aByYulYVkugPmgGBXUTY8YLJYotKw==",
+      "dev": true
     },
     "jest-util": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "husky": "^8.0.2",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "jest-sorted": "^1.0.15",
     "pg-format": "^1.0.4",
     "supertest": "^7.0.0"
   },
@@ -33,7 +34,8 @@
   },
   "jest": {
     "setupFilesAfterEnv": [
-      "jest-extended/all"
+      "jest-extended/all",
+      "jest-sorted"
     ]
   }
 }


### PR DESCRIPTION
Gets api/articles without including a body, instead including a comment count which is the total count of all the comments with this article_id. Articles are sorted by date in descending order.