### PR TITLE
Get and test /articles/&sort_by=column&order=order

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -76,7 +76,7 @@ describe("GET /api/users", () => {
 });
 
 describe("GET /api/articles", () => {
-  test("200: Responds with an array of article objects", () => {
+  test("200: Responds with an array of article objects sorted by created_at date descending as default", () => {
     return request(app)
       .get("/api/articles")
       .expect(200)
@@ -99,6 +99,164 @@ describe("GET /api/articles", () => {
             })
           );
         });
+      });
+  });
+  test("200: Responds with an array of article objects sorted by author descending as default", () => {
+    const queries = ["author"];
+    return request(app)
+      .get("/api/articles?&sort_by=author")
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles).toBeSortedBy(queries, {
+          descending: true,
+        });
+        articles.forEach((article) => {
+          expect(article).toEqual(
+            expect.objectContaining({
+              author: expect.any(String),
+              title: expect.any(String),
+              article_id: expect.any(Number),
+              topic: expect.any(String),
+              created_at: expect.any(String),
+              votes: expect.any(Number),
+              article_img_url: expect.any(String),
+              comment_count: expect.any(Number),
+            })
+          );
+        });
+      });
+  });
+  test("200: Responds with an array of article objects sorted by topic descending as default", () => {
+    const queries = ["topic"];
+    return request(app)
+      .get("/api/articles?&sort_by=topic")
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles).toBeSortedBy(queries, {
+          descending: true,
+        });
+        articles.forEach((article) => {
+          expect(article).toEqual(
+            expect.objectContaining({
+              author: expect.any(String),
+              title: expect.any(String),
+              article_id: expect.any(Number),
+              topic: expect.any(String),
+              created_at: expect.any(String),
+              votes: expect.any(Number),
+              article_img_url: expect.any(String),
+              comment_count: expect.any(Number),
+            })
+          );
+        });
+      });
+  });
+  test("200: Responds with an array of article objects sorted by author ascending", () => {
+    const queries = ["author"];
+    return request(app)
+      .get("/api/articles?&sort_by=author&order=asc")
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles).toBeSortedBy(queries, {
+          descending: false,
+        });
+        articles.forEach((article) => {
+          expect(article).toEqual(
+            expect.objectContaining({
+              author: expect.any(String),
+              title: expect.any(String),
+              article_id: expect.any(Number),
+              topic: expect.any(String),
+              created_at: expect.any(String),
+              votes: expect.any(Number),
+              article_img_url: expect.any(String),
+              comment_count: expect.any(Number),
+            })
+          );
+        });
+      });
+  });
+  test("200: Responds with an array of article objects sorted by topic ascending", () => {
+    const queries = ["topic"];
+    return request(app)
+      .get("/api/articles?&sort_by=topic&order=asc")
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles).toBeSortedBy(queries, {
+          descending: false,
+        });
+        articles.forEach((article) => {
+          expect(article).toEqual(
+            expect.objectContaining({
+              author: expect.any(String),
+              title: expect.any(String),
+              article_id: expect.any(Number),
+              topic: expect.any(String),
+              created_at: expect.any(String),
+              votes: expect.any(Number),
+              article_img_url: expect.any(String),
+              comment_count: expect.any(Number),
+            })
+          );
+        });
+      });
+  });
+  test("200: Responds with an array of article objects sorted by author descending", () => {
+    const queries = ["author"];
+    return request(app)
+      .get("/api/articles?&sort_by=author&order=desc")
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles).toBeSortedBy(queries, {
+          descending: true,
+        });
+        articles.forEach((article) => {
+          expect(article).toEqual(
+            expect.objectContaining({
+              author: expect.any(String),
+              title: expect.any(String),
+              article_id: expect.any(Number),
+              topic: expect.any(String),
+              created_at: expect.any(String),
+              votes: expect.any(Number),
+              article_img_url: expect.any(String),
+              comment_count: expect.any(Number),
+            })
+          );
+        });
+      });
+  });
+  test("200: Responds with an array of article objects sorted by topic descending", () => {
+    const queries = ["topic"];
+    return request(app)
+      .get("/api/articles?&sort_by=topic&order=desc")
+      .expect(200)
+      .then(({ body: { articles } }) => {
+        expect(articles).toBeSortedBy(queries, {
+          descending: true,
+        });
+        articles.forEach((article) => {
+          expect(article).toEqual(
+            expect.objectContaining({
+              author: expect.any(String),
+              title: expect.any(String),
+              article_id: expect.any(Number),
+              topic: expect.any(String),
+              created_at: expect.any(String),
+              votes: expect.any(Number),
+              article_img_url: expect.any(String),
+              comment_count: expect.any(Number),
+            })
+          );
+        });
+      });
+  });
+  test("400: Invalid column ID", () => {
+    return request(app)
+      .get("/api/articles?&sort_by=invalidcolumn")
+      .expect(400)
+      .then(({ body: { err } }) => {
+        expect(err).toBe("Bad Request");
       });
   });
 });

--- a/app.js
+++ b/app.js
@@ -46,7 +46,7 @@ app.all("*", (req, res) => {
 // error-handling middleware
 // 400's
 app.use((err, req, res, next) => {
-  if (err.code === "22P02") {
+  if (err.code === "22P02" || err.message === "Invalid column name") {
     res.status(400).send({ err: "Bad Request" });
   } else {
     next(err);

--- a/controllers/articles.controllers.js
+++ b/controllers/articles.controllers.js
@@ -7,7 +7,8 @@ const {
 } = require("../models/articles.models");
 
 const getArticles = (req, res, next) => {
-  fetchArticles()
+  const queries = req.query;
+  fetchArticles(queries)
     .then((articles) => {
       res.status(200).send({ articles });
     })

--- a/endpoints.json
+++ b/endpoints.json
@@ -23,7 +23,7 @@
     }
   },
   "GET /api/articles": {
-    "description": "serves an array of all articles, sorted by date ascending with a comment count that is total count of all the comments with this article_id.",
+    "description": "serves an array of all articles, sorted by date ascending with a comment count that is total count of all the comments with this article_id. array can be sorted by author or topic in ascending or descending order, with descending be default",
     "queries": ["author", "topic", "sort_by", "order"],
     "exampleResponse": {
       "articles": [


### PR DESCRIPTION
Articles endpoint now accepts the following queries:
sort_by, which sorts the articles by any valid column (defaults to the created_at date).
order, which can be set to asc or desc for ascending or descending (defaults to descending).